### PR TITLE
Issue #62 resolved here with a new some

### DIFF
--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -77,9 +77,12 @@ if (interactive()) {
      ),
      tabPanel("Add data",
              tags$h2("Add new document"),
-             shinyFilesButton('file', label="Select File", title="Select your new files from
-                            the project folder", multiple= TRUE,
-                            buttonType = "default", class = NULL),
+             ## shinyFilesButton('file', label="Select File", title="Select your new files from
+             ##                the project folder", multiple= TRUE,
+             ##                buttonType = "default", class = NULL),
+             ## textInput("file",  "The full name of your file in the document folder"),
+             uiOutput("select_new_document"),
+             uiOutput('add_new_document'),
              tags$h2("Add new unit"),
              textInput("new_unit",  "Unit name"),
              uiOutput('add_new_unit')

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -286,8 +286,7 @@ if (interactive()) {
     # Adding a new document
       observeEvent(c(input$select_project,input$update),{
           req(input$select_project)
-          doc_folder <- paste0(parseDirPath(user_folder,
-                                     input$select_project),"/documents/")
+          doc_folder <- c(paste0(project_path, "/documents/"))
           text_df <- readRDS(docs_df_path)
           old_docs <- text_df[["doc_path"]]
           files.series <- list.files(doc_folder)
@@ -309,8 +308,8 @@ if (interactive()) {
 
     observeEvent(input$send_new_document, {
       doc_folder <- c(paste0(project_path, "/documents/"))
-      files <- parseFilePaths(doc_folder, input$file)
-      qcoder::add_new_documents(files, doc_folder, docs_df_path)
+      files <- list(name = input$file)
+      qcoder::add_new_documents(files, docs_df_path, doc_folder)
     })
 
     # Set up for associating units and documents

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -281,12 +281,30 @@ if (interactive()) {
     )
 
     # Adding a new document
-    observeEvent(c(input$select_project,input$update),{
-       doc_folder <- c(paste0(input$select_project, "/documents"))
-       shinyFileChoose(input, 'file', roots = c("documents" = doc_folder))
+      observeEvent(c(input$select_project,input$update),{
+          req(input$select_project)
+          doc_folder <- paste0(parseDirPath(user_folder,
+                                     input$select_project),"/documents/")
+          text_df <- readRDS(docs_df_path)
+          old_docs <- text_df[["doc_path"]]
+          files.series <- list.files(doc_folder)
+          files.series <- grep('.txt$',
+                                   setdiff(files.series,old_docs),
+                                   value=TRUE,perl=TRUE)
+          
+          output$select_new_document <- renderUI({             
+              selectInput("file",
+                          label = "Select a new '.txt' file in the document folder of the project",
+                          choices = files.series
+                          )
+          })
+      })
+      
+    output$add_new_document <- renderUI({
+      actionButton("send_new_document", "Add new document")
     })
 
-    observeEvent(input$file, {
+    observeEvent(input$send_new_document, {
       doc_folder <- c(paste0(project_path, "/documents/"))
       files <- parseFilePaths(doc_folder, input$file)
       qcoder::add_new_documents(files, doc_folder, docs_df_path)

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -303,7 +303,8 @@ if (interactive()) {
       })
       
     output$add_new_document <- renderUI({
-      actionButton("send_new_document", "Add new document")
+        actionButton("send_new_document", "Add new document",
+                     icon = icon("share-square"))
     })
 
     observeEvent(input$send_new_document, {

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -78,7 +78,7 @@ if (interactive()) {
      tabPanel("Add data",
               tags$h2("Add new document"),
               actionButton("add_new_document", "Add a new document",
-                     icon = icon("layer-plus")),
+                     icon = icon("plus")),
              ## shinyFilesButton('file', label="Select File", title="Select your new files from
              ##                the project folder", multiple= TRUE,
              ##                buttonType = "default", class = NULL),

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -76,13 +76,14 @@ if (interactive()) {
 
      ),
      tabPanel("Add data",
-             tags$h2("Add new document"),
+              tags$h2("Add new document"),
+              actionButton("add_new_document", "Add a new document",
+                     icon = icon("layer-plus")),
              ## shinyFilesButton('file', label="Select File", title="Select your new files from
              ##                the project folder", multiple= TRUE,
              ##                buttonType = "default", class = NULL),
              ## textInput("file",  "The full name of your file in the document folder"),
-             uiOutput("select_new_document"),
-             uiOutput('add_new_document'),
+             uiOutput("selectsend_new_document"),
              tags$h2("Add new unit"),
              textInput("new_unit",  "Unit name"),
              uiOutput('add_new_unit')
@@ -100,7 +101,7 @@ if (interactive()) {
 
 
     # Select the project directory
-    user_folder <- c('Select Volume' = Sys.getenv("HOME"))
+    # user_folder <- c('Select Volume' = Sys.getenv("HOME"))
     if (user_folder != ""){
          shinyDirChoose(input, 'select_project',  roots = user_folder)
     }
@@ -284,7 +285,7 @@ if (interactive()) {
     )
 
     # Adding a new document
-      observeEvent(c(input$select_project,input$update),{
+      observeEvent(c(input$add_new_document),{
           req(input$select_project)
           doc_folder <- c(paste0(project_path, "/documents/"))
           text_df <- readRDS(docs_df_path)
@@ -294,19 +295,19 @@ if (interactive()) {
                                    setdiff(files.series,old_docs),
                                    value=TRUE,perl=TRUE)
           
-          output$select_new_document <- renderUI({             
+          output$selectsend_new_document <- renderUI({
+              tagList(
               selectInput("file",
                           label = "Select a new '.txt' file in the document folder of the project",
                           choices = files.series
-                          )
+                          ),
+              actionButton("send_new_document", "Send new document",
+                           icon = icon("share-square"))
+              )
           })
       })
       
-    output$add_new_document <- renderUI({
-        actionButton("send_new_document", "Add new document",
-                     icon = icon("share-square"))
-    })
-
+             
     observeEvent(input$send_new_document, {
       doc_folder <- c(paste0(project_path, "/documents/"))
       files <- list(name = input$file)

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -306,14 +306,12 @@ if (interactive()) {
           text_df <- readRDS(docs_df_path)
           old_docs <- text_df[["doc_path"]]
           files.series <- list.files(doc_folder)
-          files.series <- grep('.txt$',
-                                   setdiff(files.series,old_docs),
-                                   value=TRUE,perl=TRUE)
+          files.series <- setdiff(files.series,old_docs)
           
           output$selectsend_new_document <- renderUI({
               tagList(
               selectInput("file",
-                          label = "Select a new '.txt' file in the document folder of the project",
+                          label = "Select a new file in the document folder of the project",
                           choices = files.series
                           ),
               actionButton("send_new_document", "Send new document",

--- a/inst/shiny/qcoder/app.R
+++ b/inst/shiny/qcoder/app.R
@@ -101,7 +101,7 @@ if (interactive()) {
 
 
     # Select the project directory
-    # user_folder <- c('Select Volume' = Sys.getenv("HOME"))
+    user_folder <- c('Select Volume' = Sys.getenv("HOME"))
     if (user_folder != ""){
          shinyDirChoose(input, 'select_project',  roots = user_folder)
     }
@@ -300,7 +300,7 @@ if (interactive()) {
     )
 
     # Adding a new document
-      observeEvent(c(input$add_new_document),{
+      observeEvent(c(input$add_new_document,input$update),{
           req(input$select_project)
           doc_folder <- c(paste0(project_path, "/documents/"))
           text_df <- readRDS(docs_df_path)


### PR DESCRIPTION
Based on the issue 62 (freeze when added new doc) I tried to debug "shinyFileChoose", but not so easy for me.
Two facts : 
- a first bug was the order of the parameters of `qcoder::add_new_documents(files, doc_folder, docs_df_path)`
- the `doc_folder` variable are defined by two differents way in the 'app.R'. For me I had to use this : `doc_folder <- c(paste0(project_path, "/documents/"))`

Based on the comments of @elinw  I continue a previous 'hack' I tried : developing a new way for importing doc. This is the PR linked with that. It is less flexible than the shinyselection as we need to have text file in the 'document folder'. My way lists only files that are not already present. It fits with the command line "add_new_doc" function.