### PR TITLE
README format fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To test with some sample data:
 Click "Select project folder" and "my qcoder project."  
 There are two ways to add codes. To use an existing code, highlight the
 text to be coded, select the code, click "Add selected code" and then
-"Save changes." Text to be assigned a new (or exisitng) code should be
+"Save changes." Text to be assigned a new (or existing) code should be
 surrounded by (QCODER) (/QCODER) tags. The closing tag is followed
 immediately by the code enclosed in curly brackets and prefixed with a
 \# for example {\#samplecode}
@@ -138,7 +138,7 @@ sample data a minimum units file is used, but additional columns can be
 used to assign attribute data.
 
 The default file name is units.csv; if stored in a spreadsheet this can
-be creatd by using "Save As" csv.
+be created by using "Save As" csv.
 
 (Treatment of units is a work in progress and subject to change.)
 

--- a/README.md
+++ b/README.md
@@ -1,120 +1,85 @@
+
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 QCoder
 ======
 
-Lightweight package to conduct qualitative coding  
-<p>
-<img src="images/hex/imgHex.png", width="150", align="right" />
-</p>
-tl,dr
+<img src="images/hex/imgHex.png" width="150" align="right" />
+
+Lightweight package to conduct qualitative coding
+
+tl;dr
 -----
 
 To test with some sample data:
 
-    install.packages("devtools")
-    devtools::install_github("ropenscilabs/qcoder")
-    library(qcoder)
-    create_qcoder_project("my_qcoder_project", sample = TRUE)
-    import_project_data(project = "my_qcoder_project")
-    qcode()
+``` r
+install.packages("devtools")
+devtools::install_github("ropenscilabs/qcoder")
+library(qcoder)
+create_qcoder_project("my_qcoder_project", sample = TRUE)
+import_project_data(project = "my_qcoder_project")
+qcode()
+```
 
-Click "Select project folder" and "my qcoder project."  
-There are two ways to add codes. To use an existing code, highlight the
-text to be coded, select the code, click "Add selected code" and then
-"Save changes." Text to be assigned a new (or existing) code should be
-surrounded by (QCODER) (/QCODER) tags. The closing tag is followed
-immediately by the code enclosed in curly brackets and prefixed with a
-\# for example {\#samplecode}
+Click "Select project folder" and "my qcoder project."
+There are two ways to add codes. To use an existing code, highlight the text to be coded, select the code, click "Add selected code" and then "Save changes." Text to be assigned a new (or exisitng) code should be surrounded by (QCODER) (/QCODER) tags. The closing tag is followed immediately by the code enclosed in curly brackets and prefixed with a \# for example {\#samplecode}
 
 Installation
 ------------
 
 To install the latest development version, run
 
-    install.packages("devtools")
-    devtools::install_github("ropenscilabs/qcoder")
-    library(qcoder)
+``` r
+install.packages("devtools")
+devtools::install_github("ropenscilabs/qcoder")
+library(qcoder)
+```
 
-Please note that this is not a release-ready version and should be
-considered experimental and subject to changes. Still, we encourage you
-to install and send us feedback on our issue tracker.
+Please note that this is not a release-ready version and should be considered experimental and subject to changes. Still, we encourage you to install and send us feedback on our issue tracker.
 
 Motivation
 ----------
 
-The motivation stems from the need for a free, open source option for
-analyzing textual qualitative data. Textual qualitative data refers to
-text from interview transcripts, observation notes, memos, jottings and
-primary source/archival documents. A detailed discussion of the
-motivation and other software can be found in our [motivation
-document](https://github.com/ropenscilabs/qcoder/blob/master/motivation.Rmd).
+The motivation stems from the need for a free, open source option for analyzing textual qualitative data. Textual qualitative data refers to text from interview transcripts, observation notes, memos, jottings and primary source/archival documents. A detailed discussion of the motivation and other software can be found in our [motivation document](https://github.com/ropenscilabs/qcoder/blob/master/motivation.Rmd).
 
 Using QCoder
 ------------
 
-QCoder is designed to be easy to use and to require minimal knowledge of
-computer systems and code. Like all software, including other
-applications for QDA there will be a learning period, but as we develop
-Qcoder our goal will be to keep the interface simple and steadily
-improve it. Currently we have a very minimal prototype.
+QCoder is designed to be easy to use and to require minimal knowledge of computer systems and code. Like all software, including other applications for QDA there will be a learning period, but as we develop Qcoder our goal will be to keep the interface simple and steadily improve it. Currently we have a very minimal prototype.
 
 Once you have installed QCoder, load it with the library command.
 
     library(qcoder)
 
-This readme file is going to use sample data to illustrate basic QCoder
-functionality. We will be using the simplest approach which is to use
-the QCoder defaults for file names and folders. If you follow those same
-patterns and conventions with your data you can use QCoder in the same
-way. A full vignette will explain how to use non standard names and file
-locations.
+This readme file is going to use sample data to illustrate basic QCoder functionality. We will be using the simplest approach which is to use the QCoder defaults for file names and folders. If you follow those same patterns and conventions with your data you can use QCoder in the same way. A full vignette will explain how to use non standard names and file locations.
 
-To begin we will create a QCoder project with sample data. (To create an
-empty project leave out the sample option.)
+To begin we will create a QCoder project with sample data. (To create an empty project leave out the sample option.)
 
     create_qcoder_project("my_qcoder_project", sample = TRUE)
 
-This will create one main folder and four subfolders. Unless you
-specified otherwise it will be in your current working directory (you
-can find this with the `getwd()` command at the console). If you have a
-specific location where you want to put the folder change your working
-directory.
+This will create one main folder and four subfolders. Unless you specified otherwise it will be in your current working directory (you can find this with the `getwd()` command at the console). If you have a specific location where you want to put the folder change your working directory.
 
-These will hold the documents to be coded, information about the codes,
-unit information and the r data frames that will be the core of the
-analysis. For this example the folder and file structures for the sample
-data will look similar to this.
+These will hold the documents to be coded, information about the codes, unit information and the r data frames that will be the core of the analysis. For this example the folder and file structures for the sample data will look similar to this.
 
 ![](images/folderstructure.png)
 
 ### Documents
 
-In our example we've already placed our documents into the "documents"
-folder. At this point we only have tested support for txt files. If you
-have documents in other formats you can use "Save As" to convert to txt.
-If you have doc, docx, html, pdf, rtf or some other formats these can be
-processed if you install the `textreadr` package. For many users this
-will simply require
+In our example we've already placed our documents into the "documents" folder. At this point we only have tested support for txt files. If you have documents in other formats you can use "Save As" to convert to txt. If you have doc, docx, html, pdf, rtf or some other formats these can be processed if you install the `textreadr` package. For many users this will simply require
 
-    install.packages(textreadr)
+    install.packages("textreadr")
 
-However for other users, particularly those on linux systems, additional
-steps are required. Please follow the [installation instructions for
-pdftools](https://github.com/ropensci/pdftools).
+However for other users, particularly those on linux systems, additional steps are required. Please follow the [installation instructions for pdftools](https://github.com/ropensci/pdftools).
 
 ### Codes
 
-QCoder has the option to import a list of predefined codes from a CSV
-file (if you have this in a spreadsheet you can "Save As" csv). This
-file should have exactly 3 columns with headings:
+QCoder has the option to import a list of predefined codes from a CSV file (if you have this in a spreadsheet you can "Save As" csv). This file should have exactly 3 columns with headings:
 
 -   code\_id (A unique number for each code)
 -   code (One word description, can use underscores or hyphens)
--   code.description (Longer description of the code, must be enclosed
-    in quotation marks.)
+-   code.description (Longer description of the code, must be enclosed in quotation marks.)
 
-To use project defaults, this file should be called *codes.csv*. Here
-are the contents of the sample data csv file that comes with QCoder.
+To use project defaults, this file should be called *codes.csv*. Here are the contents of the sample data csv file that comes with QCoder.
 
      code_id,code,code.description
     1,"harassment","define or describes harassing behavior"
@@ -124,21 +89,13 @@ are the contents of the sample data csv file that comes with QCoder.
     5,"consequences","Detailing what happens if someone violates the code of conduct"
     6,"license","The license for this code of conduct"
 
-You are not restricted to using the listed codes in the csv file, but
-this file allows you to produce a detailed codebook including
-descriptions. (Creating a user interface for adding new codes is high
-priority item on the project road map.)
+You are not restricted to using the listed codes in the csv file, but this file allows you to produce a detailed codebook including descriptions. (Creating a user interface for adding new codes is high priority item on the project road map.)
 
 ### Units
 
-Units represent the unit of analysis data are about. Often this is
-individual people, but it may also be organizations, events or
-locations. Units may be associated with multiple documents. In the
-sample data a minimum units file is used, but additional columns can be
-used to assign attribute data.
+Units represent the unit of analysis data are about. Often this is individual people, but it may also be organizations, events or locations. Units may be associated with multiple documents. In the sample data a minimum units file is used, but additional columns can be used to assign attribute data.
 
-The default file name is units.csv; if stored in a spreadsheet this can
-be created by using "Save As" csv.
+The default file name is units.csv; if stored in a spreadsheet this can be creatd by using "Save As" csv.
 
 (Treatment of units is a work in progress and subject to change.)
 
@@ -148,12 +105,8 @@ be created by using "Save As" csv.
     3,"Carpentries"
     4,"Rladies
 
-A second file (and data frame once imported) connects units to
-documents.  
-Our framework allows each unit to be associated with multiple documents
-and each document with multiple units. (Note that the sample data is
-designed to allow you to add more unit-document links and hence does not
-link each unit to a document.)
+A second file (and data frame once imported) connects units to documents.
+Our framework allows each unit to be associated with multiple documents and each document with multiple units. (Note that the sample data is designed to allow you to add more unit-document links and hence does not link each unit to a document.)
 
     doc_path,unit_id
     CoC_Example1_mod_MU.txt,1
@@ -163,18 +116,15 @@ link each unit to a document.)
 
 ### Importing the data
 
-To import this data into Qcode user the `import_project_data()`
-function.
+To import this data into Qcode user the `import_project_data()` function.
 
     import_project_data(project = "my_qcoder_project")
 
-Now the data\_frames folder will contain the imported files.
-![](images/data_frames_folder.png)
+Now the data\_frames folder will contain the imported files. ![](images/data_frames_folder.png)
 
 Now it's time to start coding.
 
-Coding uses a "Shiny App" to provide a user interface to the data. To
-launch the app use the function `qcode()`.
+Coding uses a "Shiny App" to provide a user interface to the data. To launch the app use the function `qcode()`.
 
     qcode()
 
@@ -183,9 +133,7 @@ Which will launch this application.
 Coding
 ------
 
-Once you have selected your project there will be a drop down menu on
-the "Add codes to text" tab to allow you to pick a specific document to
-code. This will pull a document into the editor.
+Once you have selected your project there will be a drop down menu on the "Add codes to text" tab to allow you to pick a specific document to code. This will pull a document into the editor.
 
 ![](images/coding_step1.png)
 
@@ -193,63 +141,43 @@ Select your project folder.
 
 ![](images/coding_step2_folder_select.png)
 
-Once you have a project, use the drop down menu to select a particular
-document to code. This will open in an editor. When done coding
-(instructions below), click Save changes.
+Once you have a project, use the drop down menu to select a particular document to code. This will open in an editor. When done coding (instructions below), click Save changes.
 
 Select your project folder.
 
 ![](images/coding_step3_document_select.png)
 
-Switching to the "Codes" tab a list of codes from the codes file is
-displayed.
+Switching to the "Codes" tab a list of codes from the codes file is displayed.
 
 ![](images/codestab.png)
 
-Our sample data already has some coding done, and the code-text data is
-displayed on the "Coded data" tab.
+Our sample data already has some coding done, and the code-text data is displayed on the "Coded data" tab.
 
 ![](images/codeddata.png)
 
 ### Coding the data
 
-To add codes to the documents uses a tagging system. Text to be assigned
-a code should be surrounded by (QCODER) (/QCODER) tags. The closing tag
-is followed immediately by the code enclosed in curly brackets and
-prefixed with a \# for example {\#samplecode}
+To add codes to the documents uses a tagging system. Text to be assigned a code should be surrounded by (QCODER) (/QCODER) tags. The closing tag is followed immediately by the code enclosed in curly brackets and prefixed with a \# for example {\#samplecode}
 
-(QCODE)This is the text that is being assigned a
-code.(/QCODE){\#instructions}
+(QCODE)This is the text that is being assigned a code.(/QCODE){\#instructions}
 
-One pair of {} can contain multiple codes, each with at \# and separated
-by commas.
+One pair of {} can contain multiple codes, each with at \# and separated by commas.
 
-Alternatively, to use an existing code, highlight the text to be coded,
-select the code or codes, click "Add selected code."
+Alternatively, to use an existing code, highlight the text to be coded, select the code or codes, click "Add selected code."
 
-When you have finished coding a document press the "Save changes"
-button.
+When you have finished coding a document press the "Save changes" button.
 
 ### Cautions and known issues
 
-Each time you save, Qcoder makes a backup copy of your documents data
-frame. This is for safety and reproducability. This can end up with a
-lot of files if you save often. You may want to periodically delete some
-backups to save storage space.
+Each time you save, Qcoder makes a backup copy of your documents data frame. This is for safety and reproducability. This can end up with a lot of files if you save often. You may want to periodically delete some backups to save storage space.
 
-Currently when you create a new code while coding, this code will be
-displayed on the Coded data tab, but not on the Codes or Summary tabs.
-You must restart the qcode application to update those displays. This is
-a high priority development item.
+Currently when you create a new code while coding, this code will be displayed on the Coded data tab, but not on the Codes or Summary tabs. You must restart the qcode application to update those displays. This is a high priority development item.
 
 ### Road map
 
-QCoder can be used right now for coding. However, we are not yet ready
-for release.
+QCoder can be used right now for coding. However, we are not yet ready for release.
 
-Our immediate goal is to create a somewhat more advanced minimum viable
-product. This includes creating user interfaces to add new documents,
-codes and units and adding javascript support for inserting codes.
+Our immediate goal is to create a somewhat more advanced minimum viable product. This includes creating user interfaces to add new documents, codes and units and adding javascript support for inserting codes.
 
 Contributors
 ------------

--- a/README.md
+++ b/README.md
@@ -1,85 +1,120 @@
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 QCoder
 ======
 
-<img src="images/hex/imgHex.png" width="150" align="right" />
+Lightweight package to conduct qualitative coding.
 
-Lightweight package to conduct qualitative coding
+<img src="images/hex/imgHex.png" width="150" />
 
 tl;dr
 -----
 
 To test with some sample data:
 
-``` r
-install.packages("devtools")
-devtools::install_github("ropenscilabs/qcoder")
-library(qcoder)
-create_qcoder_project("my_qcoder_project", sample = TRUE)
-import_project_data(project = "my_qcoder_project")
-qcode()
-```
+    install.packages("devtools")
+    devtools::install_github("ropenscilabs/qcoder")
+    library(qcoder)
+    create_qcoder_project("my_qcoder_project", sample = TRUE)
+    import_project_data(project = "my_qcoder_project")
+    qcode()
 
-Click "Select project folder" and "my qcoder project."
-There are two ways to add codes. To use an existing code, highlight the text to be coded, select the code, click "Add selected code" and then "Save changes." Text to be assigned a new (or exisitng) code should be surrounded by (QCODER) (/QCODER) tags. The closing tag is followed immediately by the code enclosed in curly brackets and prefixed with a \# for example {\#samplecode}
+Click "Select project folder" and "my qcoder project."  
+There are two ways to add codes. To use an existing code, highlight the
+text to be coded, select the code, click "Add selected code" and then
+"Save changes." Text to be assigned a new (or exisitng) code should be
+surrounded by (QCODER) (/QCODER) tags. The closing tag is followed
+immediately by the code enclosed in curly brackets and prefixed with a
+\# for example {\#samplecode}
 
 Installation
 ------------
 
 To install the latest development version, run
 
-``` r
-install.packages("devtools")
-devtools::install_github("ropenscilabs/qcoder")
-library(qcoder)
-```
+    install.packages("devtools")
+    devtools::install_github("ropenscilabs/qcoder")
+    library(qcoder)
 
-Please note that this is not a release-ready version and should be considered experimental and subject to changes. Still, we encourage you to install and send us feedback on our issue tracker.
+Please note that this is not a release-ready version and should be
+considered experimental and subject to changes. Still, we encourage you
+to install and send us feedback on our issue tracker.
 
 Motivation
 ----------
 
-The motivation stems from the need for a free, open source option for analyzing textual qualitative data. Textual qualitative data refers to text from interview transcripts, observation notes, memos, jottings and primary source/archival documents. A detailed discussion of the motivation and other software can be found in our [motivation document](https://github.com/ropenscilabs/qcoder/blob/master/motivation.Rmd).
+The motivation stems from the need for a free, open source option for
+analyzing textual qualitative data. Textual qualitative data refers to
+text from interview transcripts, observation notes, memos, jottings and
+primary source/archival documents. A detailed discussion of the
+motivation and other software can be found in our [motivation
+document](https://github.com/ropenscilabs/qcoder/blob/master/motivation.Rmd).
 
 Using QCoder
 ------------
 
-QCoder is designed to be easy to use and to require minimal knowledge of computer systems and code. Like all software, including other applications for QDA there will be a learning period, but as we develop Qcoder our goal will be to keep the interface simple and steadily improve it. Currently we have a very minimal prototype.
+QCoder is designed to be easy to use and to require minimal knowledge of
+computer systems and code. Like all software, including other
+applications for QDA there will be a learning period, but as we develop
+Qcoder our goal will be to keep the interface simple and steadily
+improve it. Currently we have a very minimal prototype.
 
 Once you have installed QCoder, load it with the library command.
 
     library(qcoder)
 
-This readme file is going to use sample data to illustrate basic QCoder functionality. We will be using the simplest approach which is to use the QCoder defaults for file names and folders. If you follow those same patterns and conventions with your data you can use QCoder in the same way. A full vignette will explain how to use non standard names and file locations.
+This readme file is going to use sample data to illustrate basic QCoder
+functionality. We will be using the simplest approach which is to use
+the QCoder defaults for file names and folders. If you follow those same
+patterns and conventions with your data you can use QCoder in the same
+way. A full vignette will explain how to use non standard names and file
+locations.
 
-To begin we will create a QCoder project with sample data. (To create an empty project leave out the sample option.)
+To begin we will create a QCoder project with sample data. (To create an
+empty project leave out the sample option.)
 
     create_qcoder_project("my_qcoder_project", sample = TRUE)
 
-This will create one main folder and four subfolders. Unless you specified otherwise it will be in your current working directory (you can find this with the `getwd()` command at the console). If you have a specific location where you want to put the folder change your working directory.
+This will create one main folder and four subfolders. Unless you
+specified otherwise it will be in your current working directory (you
+can find this with the `getwd()` command at the console). If you have a
+specific location where you want to put the folder change your working
+directory.
 
-These will hold the documents to be coded, information about the codes, unit information and the r data frames that will be the core of the analysis. For this example the folder and file structures for the sample data will look similar to this.
+These will hold the documents to be coded, information about the codes,
+unit information and the r data frames that will be the core of the
+analysis. For this example the folder and file structures for the sample
+data will look similar to this.
 
 ![](images/folderstructure.png)
 
 ### Documents
 
-In our example we've already placed our documents into the "documents" folder. At this point we only have tested support for txt files. If you have documents in other formats you can use "Save As" to convert to txt. If you have doc, docx, html, pdf, rtf or some other formats these can be processed if you install the `textreadr` package. For many users this will simply require
+In our example we've already placed our documents into the "documents"
+folder. At this point we only have tested support for txt files. If you
+have documents in other formats you can use "Save As" to convert to txt.
+If you have doc, docx, html, pdf, rtf or some other formats these can be
+processed if you install the `textreadr` package. For many users this
+will simply require
 
     install.packages("textreadr")
 
-However for other users, particularly those on linux systems, additional steps are required. Please follow the [installation instructions for pdftools](https://github.com/ropensci/pdftools).
+However for other users, particularly those on linux systems, additional
+steps are required. Please follow the [installation instructions for
+pdftools](https://github.com/ropensci/pdftools).
 
 ### Codes
 
-QCoder has the option to import a list of predefined codes from a CSV file (if you have this in a spreadsheet you can "Save As" csv). This file should have exactly 3 columns with headings:
+QCoder has the option to import a list of predefined codes from a CSV
+file (if you have this in a spreadsheet you can "Save As" csv). This
+file should have exactly 3 columns with headings:
 
 -   code\_id (A unique number for each code)
 -   code (One word description, can use underscores or hyphens)
--   code.description (Longer description of the code, must be enclosed in quotation marks.)
+-   code.description (Longer description of the code, must be enclosed
+    in quotation marks.)
 
-To use project defaults, this file should be called *codes.csv*. Here are the contents of the sample data csv file that comes with QCoder.
+To use project defaults, this file should be called *codes.csv*. Here
+are the contents of the sample data csv file that comes with QCoder.
 
      code_id,code,code.description
     1,"harassment","define or describes harassing behavior"
@@ -89,13 +124,21 @@ To use project defaults, this file should be called *codes.csv*. Here are the co
     5,"consequences","Detailing what happens if someone violates the code of conduct"
     6,"license","The license for this code of conduct"
 
-You are not restricted to using the listed codes in the csv file, but this file allows you to produce a detailed codebook including descriptions. (Creating a user interface for adding new codes is high priority item on the project road map.)
+You are not restricted to using the listed codes in the csv file, but
+this file allows you to produce a detailed codebook including
+descriptions. (Creating a user interface for adding new codes is high
+priority item on the project road map.)
 
 ### Units
 
-Units represent the unit of analysis data are about. Often this is individual people, but it may also be organizations, events or locations. Units may be associated with multiple documents. In the sample data a minimum units file is used, but additional columns can be used to assign attribute data.
+Units represent the unit of analysis data are about. Often this is
+individual people, but it may also be organizations, events or
+locations. Units may be associated with multiple documents. In the
+sample data a minimum units file is used, but additional columns can be
+used to assign attribute data.
 
-The default file name is units.csv; if stored in a spreadsheet this can be creatd by using "Save As" csv.
+The default file name is units.csv; if stored in a spreadsheet this can
+be creatd by using "Save As" csv.
 
 (Treatment of units is a work in progress and subject to change.)
 
@@ -105,8 +148,12 @@ The default file name is units.csv; if stored in a spreadsheet this can be creat
     3,"Carpentries"
     4,"Rladies
 
-A second file (and data frame once imported) connects units to documents.
-Our framework allows each unit to be associated with multiple documents and each document with multiple units. (Note that the sample data is designed to allow you to add more unit-document links and hence does not link each unit to a document.)
+A second file (and data frame once imported) connects units to
+documents.  
+Our framework allows each unit to be associated with multiple documents
+and each document with multiple units. (Note that the sample data is
+designed to allow you to add more unit-document links and hence does not
+link each unit to a document.)
 
     doc_path,unit_id
     CoC_Example1_mod_MU.txt,1
@@ -116,15 +163,18 @@ Our framework allows each unit to be associated with multiple documents and each
 
 ### Importing the data
 
-To import this data into Qcode user the `import_project_data()` function.
+To import this data into Qcode user the `import_project_data()`
+function.
 
     import_project_data(project = "my_qcoder_project")
 
-Now the data\_frames folder will contain the imported files. ![](images/data_frames_folder.png)
+Now the data\_frames folder will contain the imported files.
+![](images/data_frames_folder.png)
 
 Now it's time to start coding.
 
-Coding uses a "Shiny App" to provide a user interface to the data. To launch the app use the function `qcode()`.
+Coding uses a "Shiny App" to provide a user interface to the data. To
+launch the app use the function `qcode()`.
 
     qcode()
 
@@ -133,7 +183,9 @@ Which will launch this application.
 Coding
 ------
 
-Once you have selected your project there will be a drop down menu on the "Add codes to text" tab to allow you to pick a specific document to code. This will pull a document into the editor.
+Once you have selected your project there will be a drop down menu on
+the "Add codes to text" tab to allow you to pick a specific document to
+code. This will pull a document into the editor.
 
 ![](images/coding_step1.png)
 
@@ -141,43 +193,63 @@ Select your project folder.
 
 ![](images/coding_step2_folder_select.png)
 
-Once you have a project, use the drop down menu to select a particular document to code. This will open in an editor. When done coding (instructions below), click Save changes.
+Once you have a project, use the drop down menu to select a particular
+document to code. This will open in an editor. When done coding
+(instructions below), click Save changes.
 
 Select your project folder.
 
 ![](images/coding_step3_document_select.png)
 
-Switching to the "Codes" tab a list of codes from the codes file is displayed.
+Switching to the "Codes" tab a list of codes from the codes file is
+displayed.
 
 ![](images/codestab.png)
 
-Our sample data already has some coding done, and the code-text data is displayed on the "Coded data" tab.
+Our sample data already has some coding done, and the code-text data is
+displayed on the "Coded data" tab.
 
 ![](images/codeddata.png)
 
 ### Coding the data
 
-To add codes to the documents uses a tagging system. Text to be assigned a code should be surrounded by (QCODER) (/QCODER) tags. The closing tag is followed immediately by the code enclosed in curly brackets and prefixed with a \# for example {\#samplecode}
+To add codes to the documents uses a tagging system. Text to be assigned
+a code should be surrounded by (QCODER) (/QCODER) tags. The closing tag
+is followed immediately by the code enclosed in curly brackets and
+prefixed with a \# for example {\#samplecode}
 
-(QCODE)This is the text that is being assigned a code.(/QCODE){\#instructions}
+(QCODE)This is the text that is being assigned a
+code.(/QCODE){\#instructions}
 
-One pair of {} can contain multiple codes, each with at \# and separated by commas.
+One pair of {} can contain multiple codes, each with at \# and separated
+by commas.
 
-Alternatively, to use an existing code, highlight the text to be coded, select the code or codes, click "Add selected code."
+Alternatively, to use an existing code, highlight the text to be coded,
+select the code or codes, click "Add selected code."
 
-When you have finished coding a document press the "Save changes" button.
+When you have finished coding a document press the "Save changes"
+button.
 
 ### Cautions and known issues
 
-Each time you save, Qcoder makes a backup copy of your documents data frame. This is for safety and reproducability. This can end up with a lot of files if you save often. You may want to periodically delete some backups to save storage space.
+Each time you save, Qcoder makes a backup copy of your documents data
+frame. This is for safety and reproducability. This can end up with a
+lot of files if you save often. You may want to periodically delete some
+backups to save storage space.
 
-Currently when you create a new code while coding, this code will be displayed on the Coded data tab, but not on the Codes or Summary tabs. You must restart the qcode application to update those displays. This is a high priority development item.
+Currently when you create a new code while coding, this code will be
+displayed on the Coded data tab, but not on the Codes or Summary tabs.
+You must restart the qcode application to update those displays. This is
+a high priority development item.
 
 ### Road map
 
-QCoder can be used right now for coding. However, we are not yet ready for release.
+QCoder can be used right now for coding. However, we are not yet ready
+for release.
 
-Our immediate goal is to create a somewhat more advanced minimum viable product. This includes creating user interfaces to add new documents, codes and units and adding javascript support for inserting codes.
+Our immediate goal is to create a somewhat more advanced minimum viable
+product. This includes creating user interfaces to add new documents,
+codes and units and adding javascript support for inserting codes.
 
 Contributors
 ------------

--- a/README.rmd
+++ b/README.rmd
@@ -1,13 +1,13 @@
 ---
-output: github_document
+output: md_document
 ---
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # QCoder
 
-<img src="images/hex/imgHex.png" width="150" align="right" />
+Lightweight package to conduct qualitative coding.
 
-Lightweight package to conduct qualitative coding
+<img src="images/hex/imgHex.png" width="150" />
 
 ## tl;dr
 

--- a/README.rmd
+++ b/README.rmd
@@ -1,15 +1,18 @@
 ---
-output: 
- md_document
+output: github_document
 ---
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-# QCoder
-Lightweight package to conduct qualitative coding  
-<p><img src="images/hex/imgHex.png", width="150", align="right" /></p>
 
-## tl,dr  
+# QCoder
+
+<img src="images/hex/imgHex.png" width="150" align="right" />
+
+Lightweight package to conduct qualitative coding
+
+## tl;dr
 
 To test with some sample data:
+
 ```r
 install.packages("devtools")
 devtools::install_github("ropenscilabs/qcoder")
@@ -18,6 +21,7 @@ create_qcoder_project("my_qcoder_project", sample = TRUE)
 import_project_data(project = "my_qcoder_project")
 qcode()
 ```
+
 Click "Select project folder" and "my qcoder project."  
 There are two ways to add codes. To use an existing code, highlight the text
 to be coded, select the code, click "Add selected code" and then 
@@ -97,7 +101,7 @@ If you have documents in other formats you can use
 "Save As" to convert to txt.   If you have doc, docx, html, pdf, rtf or some other formats
 these can be processed if you install the `textreadr` package.  For many users this will simply require
 ```
-install.packages(textreadr)
+install.packages("textreadr")
 ```
 However for other users, particularly those on linux systems, additional steps are required. Please follow
 the [installation instructions for pdftools](https://github.com/ropensci/pdftools).

--- a/README.rmd
+++ b/README.rmd
@@ -25,7 +25,7 @@ qcode()
 Click "Select project folder" and "my qcoder project."  
 There are two ways to add codes. To use an existing code, highlight the text
 to be coded, select the code, click "Add selected code" and then 
-"Save changes." Text to be assigned a  new (or exisitng) code should be
+"Save changes." Text to be assigned a  new (or existing) code should be
 surrounded by (QCODER) (/QCODER) tags. The closing tag is followed immediately
 by the code enclosed in curly brackets and prefixed with a # for example
 {#samplecode}
@@ -141,7 +141,7 @@ Units may be associated with multiple documents.
 In the sample data a minimum units file is used, but additional columns can
 be used to assign attribute data. 
 
-The default file name is units.csv; if stored in a spreadsheet this can be creatd by
+The default file name is units.csv; if stored in a spreadsheet this can be created by
 using "Save As" csv.
 
 (Treatment of units is a work in progress and subject to change.)


### PR DESCRIPTION
I am kinda ignoring the contributing guidelines, because I just fixed some typos on the README.
Needed the "" when installing packages, so I updated that and "fixed" the TL;DR on the title. I couldn't make it work for the right aligned though, there's something with this way of inserting the image that would make it free float on the screen. However, this PR just makes the Tl;DR render correctly for now.

Kinda related to issue #84?