### PR TITLE
Adds caching to Travis, making the CI builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,3 @@ addons:
       - libpoppler-cpp-dev
       - poppler-data
       - valgrind
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ addons:
       - libpoppler-cpp-dev
       - poppler-data
       - valgrind
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
-sudo: required
+sudo: false
+cache: packages
 warnings_are_errors: true
 env:
   global:


### PR DESCRIPTION
As per issue #87: On my fork, the build went from 21 minutes to 3 minutes 31 sec. See [here](https://travis-ci.com/Yuri-M-Dias/qcoder/builds/89704715)
This just adds basic caching capabilities on travis, since that container-based structure is generally faster.