### PR TITLE
Adding a base makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Based on https://github.com/robjhyndman/forecast/blob/master/Makefile
+# Makefile for generating R packages, modified.
+# Assumes Makefile is in top folder of package
+
+PKG_NAME="qcoder" # Bash code removed due to R CMD CHECK failure
+
+all: install
+
+check:
+	Rscript -e "devtools::check(document=TRUE)"
+
+build:
+	Rscript -e "devtools::build()"
+
+test:
+	Rscript -e "devtools::test()"
+
+install:
+	Rscript -e "devtools::install()"
+
+docs:
+	Rscript -e "devtools::document()"
+
+clean:
+	-rm -f ../$(PKG_NAME)_*.tar.gz
+	#-rm -r -f man/*.Rd
+	#-rm -r -f NAMESPACE
+


### PR DESCRIPTION
As I said in issue #86, this is just to add a standard way of compiling and development.
To me this has the bonus point of working outside of RStudio, but it could certainly be improved. As I said in the issue, this might not be all that interesting if the developers already have a standard way of doing this, I just couldn't find it.