### PR TITLE
nested codes identical strings

### DIFF
--- a/R/parse_qcodes.R
+++ b/R/parse_qcodes.R
@@ -30,7 +30,9 @@ parse_qcodes <- function(x, ...){
 
     #split the file on opening qcode tags
     #note: can't just use str_extract_all() with a nice clean regex, because qcodes can be nested
-    splititems <- unlist( strsplit( x$document_text[i], "(\\(QCODE\\))") )
+    splititems <- gsub("^$"," ",
+                       unlist( strsplit( x$document_text[i], "(\\(QCODE\\))") )
+                       )
 
     ### skip this document/row if no qcodes were found
     if( length(splititems) == 1 ){


### PR DESCRIPTION
Just adding a white space in the stringsplit in the parsing function seems to be Ok for me. 
Tested with multiple nested (up to 4 or 5 same string).

NB : 
-I see well that in the traditional coding of qcoder, we can add multiple codes at once, but we can expect that some people will add them it in different steps.
-it is linked also with the development of the cog-map module (on my fork) where I have an indirect manner to add codes. 